### PR TITLE
Bugfix for karma configs for MOCK_APIS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+    - "0.10"

--- a/config/karma/config.js
+++ b/config/karma/config.js
@@ -6,6 +6,7 @@
 'use strict';
 
 var path = require('path');
+var webpack = require('webpack');
 var loaders = require('../webpack/loaders');
 var resolve = require('../webpack/resolve');
 
@@ -75,6 +76,11 @@ module.exports = function (config) {
                 }],
                 loaders: loaders,
             },
+            plugins: [
+                new webpack.DefinePlugin({
+                    MOCK_APIS: false,
+                })
+            ],
             resolve: resolve,
             devtool: 'inline-source-map',
         },

--- a/package.json
+++ b/package.json
@@ -84,7 +84,8 @@
   },
   "scripts": {
     "prepublish": "bin/pre-publish.sh",
-    "postpublish": "bin/post-publish.sh"
+    "postpublish": "bin/post-publish.sh",
+    "test": "make node-test"
   },
   "bin": {
     "beaker": "./bin/beaker.js",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   "scripts": {
     "prepublish": "bin/pre-publish.sh",
     "postpublish": "bin/post-publish.sh",
-    "test": "make node-test"
+    "test": "make test"
   },
   "bin": {
     "beaker": "./bin/beaker.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beaker",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Toolkit for building web interfaces",
   "main": "src/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   "scripts": {
     "prepublish": "bin/pre-publish.sh",
     "postpublish": "bin/post-publish.sh",
-    "test": "make test"
+    "test": "make node-test"
   },
   "bin": {
     "beaker": "./bin/beaker.js",


### PR DESCRIPTION
When using the webpack.DefinePlugin, it's important to default
the globals everywhere, or webpack fails to build at all.