### PR TITLE
Adds build-mock make target and updates e2e-test

### DIFF
--- a/make/common.mk
+++ b/make/common.mk
@@ -13,6 +13,7 @@ BEAKER_BIN ?= beaker
 
 .PHONY: \
 	build \
+	build-mock \
 	lint \
 	package-test \
 	update-eslintrc \
@@ -21,6 +22,9 @@ BEAKER_BIN ?= beaker
 
 build:
 	$(ENV)grunt build
+
+build-mock:
+	$(ENV)grunt build-mock
 
 lint:
 ifeq ($(IS_BEAKER), 1)

--- a/make/webpack-targets.mk
+++ b/make/webpack-targets.mk
@@ -42,8 +42,8 @@ do-e2e-test:
 	$(ENV)jasmine-node $(JASMINE_NODE_OPTS) $(NODE_SPECS) || ($(ENV)kill $$(lsof -t -i:$(TEST_PORT)) && false)
 	$(ENV)kill $$(lsof -t -i:$(TEST_PORT)) || echo 'nothing to kill'
 
-e2e-test: kill-httpserver build start-httpserver create-config do-e2e-test
-e2e-test-local: kill-httpserver build start-httpserver create-config-local do-e2e-test
+e2e-test: kill-httpserver build-mock start-httpserver create-config do-e2e-test
+e2e-test-local: kill-httpserver build-mock start-httpserver create-config-local do-e2e-test
 
 #######################################################################
 #                         normal test targets                         #

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beaker",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "description": "Toolkit for building web interfaces",
   "main": "src/index.js",
   "repository": {


### PR DESCRIPTION
The `build-mock` make target is now available for all project types.

The `e2e-test` make target has been updated to use `build-mock` instead
of `build` in order to make sure no real APIs are used when running the
`e2e-test` target.