### PR TITLE
Add eslint rule for lodash aliases

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -55,6 +55,7 @@
         "no-empty": 2,
         "no-extend-native": 2,
         "no-floating-decimal": 2,
+        "no-lodash-aliases": 2,
         "no-lone-blocks": 2,
         "no-loop-func": 2,
         "no-multi-str": 2,

--- a/files/project-templates/common/.eslintrc
+++ b/files/project-templates/common/.eslintrc
@@ -55,6 +55,7 @@
         "no-empty": 2,
         "no-extend-native": 2,
         "no-floating-decimal": 2,
+        "no-lodash-aliases": 2,
         "no-lone-blocks": 2,
         "no-loop-func": 2,
         "no-multi-str": 2,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beaker",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Toolkit for building web interfaces",
   "main": "src/index.js",
   "repository": {

--- a/spec/cli/argv-spec.js
+++ b/spec/cli/argv-spec.js
@@ -17,7 +17,7 @@ var cli = t.require('./index');
  * @returns {Object} an argv object appropriate to pass to a CLI command method
 */
 function constructArgv(args, options) {
-    return _.extend({
+    return _.assign({
         _: args || [],
     }, options);
 }

--- a/spec/eslint-rules/no-lodash-aliases-spec.js
+++ b/spec/eslint-rules/no-lodash-aliases-spec.js
@@ -1,22 +1,22 @@
 /**
- * @file spec for indent eslint rule
+ * @file spec for no-lodash-alias eslint rule
  * @copyright 2014-2015 Cyan, Inc. All rights reserved
 */
 
 'use strict';
 
 var t = require('../../src/transplant')(__dirname);
-var indent = t.require('./indent');
+var noAliases = t.require('./no-lodash-aliases');
 
-describe('indent', function () {
+describe('noAliases', function () {
     // NOTE: We don't have a proper test for the indent rule
     // because we did not write it, but rather took it from
-    // https://github.com/nodeca/eslint-plugin-nodeca/blob/master/lib/indent.js
+    // https://github.com/nodeca/eslint-plugin-nodeca/blob/master/lib/no-lodash-aliases.js
     it('exists', function () {
-        expect(indent).not.toBeUndefined();
+        expect(noAliases).not.toBeUndefined();
     });
 
     it('is a function', function () {
-        expect(typeof indent).toBe('function');
+        expect(typeof noAliases).toBe('function');
     });
 });

--- a/spec/github-spec.js
+++ b/spec/github-spec.js
@@ -544,7 +544,7 @@ describe('github', function () {
     });
 
     describe('.specifiesVersionBumpLevel()', function () {
-        _.each(['MAJOR', 'MINOR', 'PATCH'], function (level) {
+        _.forEach(['MAJOR', 'MINOR', 'PATCH'], function (level) {
             it('returns true if ' + level + ' bump comment', function () {
                 var pr = {body: '#' + level + '#'};
                 expect(github.specifiesVersionBumpLevel(pr)).toBeTruthy();

--- a/spec/grunt/helper-spec.js
+++ b/spec/grunt/helper-spec.js
@@ -143,7 +143,7 @@ describe('grunt helper', function () {
 
             var files = dirContents['coverage-dir/sub-dir'];
 
-            _.each(files, function (filename) {
+            _.forEach(files, function (filename) {
                 expect(rimraf.sync).toHaveBeenCalledWith(dest(filename));
                 expect(fs.renameSync).toHaveBeenCalledWith(src(filename), dest(filename));
             });

--- a/spec/init-spec.js
+++ b/spec/init-spec.js
@@ -92,7 +92,7 @@ describe('init', function () {
             });
         });
 
-        _.each(['app', 'node', 'webpack'], function (projectType) {
+        _.forEach(['app', 'node', 'webpack'], function (projectType) {
             describe(projectType + ' project', function () {
                 beforeEach(function () {
                     templateData.projectType = projectType;
@@ -116,7 +116,7 @@ describe('init', function () {
                 });
 
                 it('checks for symlinks', function () {
-                    _.each(originalSymlinks, function (symlink) {
+                    _.forEach(originalSymlinks, function (symlink) {
                         expect(fs.existsSync).toHaveBeenCalledWith(symlink);
                         expect(fs.unlink).not.toHaveBeenCalledWith(symlink);
                     });

--- a/spec/utils-spec.js
+++ b/spec/utils-spec.js
@@ -91,7 +91,7 @@ describe('utils', function () {
                 spyOn(fs, 'createWriteStream').and.returnValue(outStr);
             });
 
-            _.each(IMAGE_FILES, function (imageFilename) {
+            _.forEach(IMAGE_FILES, function (imageFilename) {
                 describe('copying ' + imageFilename, function () {
                     var srcPath, dstPath;
 
@@ -293,7 +293,7 @@ describe('utils', function () {
             expect(utils.removeHeadDir('head/or/tail')).toEqual('or/tail');
         });
 
-        _.each(['gitattributes', 'gitignore', 'gitfat'], function (fileName) {
+        _.forEach(['gitattributes', 'gitignore', 'gitfat'], function (fileName) {
             it('adds . to filename if filename is ' + fileName, function () {
                 expect(utils.removeHeadDir('path/to/' + fileName)).toEqual('to/.' + fileName);
             });

--- a/src/eslint-rules/no-lodash-aliases.js
+++ b/src/eslint-rules/no-lodash-aliases.js
@@ -1,0 +1,62 @@
+/**
+ * @fileoverview Rule to flag use of lodash (library) aliases
+ * @author Nodeca Team <https://github.com/nodeca>
+ */
+
+'use strict';
+
+var LODASH_FN_ALIASES = {
+    drop: 'rest',
+    head: 'first',
+    object: 'zipObject',
+    tail: 'rest',
+    take: 'first',
+    unique: 'uniq',
+    unzip: 'zip',
+    all: 'every',
+    any: 'some',
+    collect: 'map',
+    detect: 'find',
+    each: 'forEach',
+    eachRight: 'forEachRight',
+    findWhere: 'find',
+    foldl: 'reduce',
+    foldr: 'reduceRight',
+    include: 'contains',
+    inject: 'reduce',
+    select: 'filter',
+    extend: 'assign',
+    methods: 'functions',
+};
+
+var LODASH_NAMES = ['lodash', '_'];
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function (context) {
+
+    return {
+        'CallExpression': function detectLodashAlias(node) {
+
+            var callee = node.callee;
+
+            // Check patterns like `_.each(..)`,
+            // that should be <Identifier.MemberExpression>
+
+            if (callee.type === 'MemberExpression' && LODASH_FN_ALIASES.hasOwnProperty(callee.property.name)) {
+
+                var parentName = callee.object.name;
+
+                if (callee.object.type === 'Identifier' && LODASH_NAMES.indexOf(parentName) !== -1) {
+                    context.report(node, '{{ldh}}.{{alias}}() is alias, use {{ldh}}.{{method}}() instead.', {
+                        ldh: parentName,
+                        alias: callee.property.name,
+                        method: LODASH_FN_ALIASES[callee.property.name],
+                    });
+                }
+            }
+        }
+    };
+};

--- a/src/github.js
+++ b/src/github.js
@@ -174,7 +174,7 @@ ns.getPullRequestForSHA = function (repo, sha, searchAll) {
     var pullRequests = ns.getPullRequests(repo, searchAll);
 
     // Iterate over all open pull requests
-    _.each(pullRequests, function (pr) {
+    _.forEach(pullRequests, function (pr) {
         // If pull request is at specific commit
         if (pr.head.sha === sha || pr.merge_commit_sha === sha) {
             console.log('Found PR at commit: ' + pr.id);
@@ -220,7 +220,7 @@ ns.specifiesVersionBumpLevel = function (pr) {
 ns.missingArgs = function (argv, required) {
     var argsMissing = false;
 
-    _.each(required, function (arg) {
+    _.forEach(required, function (arg) {
         if (!_.has(argv, arg)) {
             console.error(arg + ' argument is required');
             argsMissing = true;
@@ -321,7 +321,7 @@ ns.pushChanges = function () {
  * @returns {Boolean} whether or not commit succeeded
  */
 ns.commitBumpedFiles = function () {
-    _.each(['bower.json', 'package.json'], function (file) {
+    _.forEach(['bower.json', 'package.json'], function (file) {
         var filePath = path.join(CWD, file);
 
         // If file exists make sure to add it to git
@@ -357,7 +357,7 @@ ns.bumpVersion = function (argv) {
 
     var bumps = [];
 
-    _.each(commits, function (commitObj) {
+    _.forEach(commits, function (commitObj) {
         // If commit was made by buildbot we can ignore all previous commits
         if (commitObj.commit.author.email === getConfig().github.email) {
             return false;
@@ -385,7 +385,7 @@ ns.bumpVersion = function (argv) {
         }
     });
 
-    _.each(bumps, function (bump) {
+    _.forEach(bumps, function (bump) {
         // If failed to bump files
         if (!ns.bumpFiles(bump)) {
             error = true;

--- a/src/grunt/helper.js
+++ b/src/grunt/helper.js
@@ -32,7 +32,7 @@ ns.moveCoverageUp = function (coverageDir, logFn) {
         logFn('found coverage directory at: ' + fullSubDir);
     }
 
-    _.each(fs.readdirSync(fullSubDir), function (file) {
+    _.forEach(fs.readdirSync(fullSubDir), function (file) {
         var dest = path.join(coverageDir, file);
         rimraf.sync(dest);
         fs.renameSync(path.join(fullSubDir, file), dest);

--- a/src/init.js
+++ b/src/init.js
@@ -75,7 +75,7 @@ ns.command = function (argv) {
     utils.copyDir(projectType, CWD, templateData);
 
     // clean up symlinks, if they exist
-    _.each(['src', 'spec', 'node-spec'], function (pathElement) {
+    _.forEach(['src', 'spec', 'node-spec'], function (pathElement) {
         var fullPath = path.join(CWD, pathElement, 'project-name');
         if (fs.existsSync(fullPath)) {
             fs.unlink(fullPath);

--- a/src/test-utils.js
+++ b/src/test-utils.js
@@ -74,7 +74,7 @@ ns.waitForPromise = function (done, promise, callback) {
 ns.cssCallback = function (screenshots) {
     return function (err, res) {
         expect(err).toBeFalsy();
-        _.each(screenshots, function (screenshot) {
+        _.forEach(screenshots, function (screenshot) {
             expect(res[screenshot.name][0].isWithinMisMatchTolerance).toBeTruthy();
         });
     };

--- a/src/utils.js
+++ b/src/utils.js
@@ -146,7 +146,7 @@ ns.copyDir = function (dir, destination, data) {
     ns.mkdirSync(destPath);
 
     // Iterate contents of directory
-    _.each(fs.readdirSync(srcPath), function (relPath) {
+    _.forEach(fs.readdirSync(srcPath), function (relPath) {
         var fullPath = path.join(srcPath, relPath);
         ns.processPath(fullPath, destination, data);
     });


### PR DESCRIPTION
Fix for issue #14, updated `.eslintrc` to include the `no-lodash-aliases` rule
from `nodeca`.