### PR TITLE
Added a custom eslint rule `no-redeclare-func`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -62,6 +62,8 @@
         "no-native-reassign": 2,
         "no-new": 2,
         "no-new-wrappers": 2,
+        "no-redeclare": 2,
+        "no-redeclare-func": 2,
         "no-space-before-semi": 2,
         "no-trailing-spaces": 2,
         "no-unused-vars": [2, {"vars": "all", "args": "after-used"}],

--- a/files/project-templates/common/.eslintrc
+++ b/files/project-templates/common/.eslintrc
@@ -62,6 +62,8 @@
         "no-native-reassign": 2,
         "no-new": 2,
         "no-new-wrappers": 2,
+        "no-redeclare": 2,
+        "no-redeclare-func": 2,
         "no-space-before-semi": 2,
         "no-trailing-spaces": 2,
         "no-unused-vars": [2, {"vars": "all", "args": "after-used"}],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beaker",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Toolkit for building web interfaces",
   "main": "src/index.js",
   "repository": {

--- a/spec/eslint-rules/no-dupe-func.js
+++ b/spec/eslint-rules/no-dupe-func.js
@@ -1,0 +1,19 @@
+/**
+ * @file spec for no-dupe-func eslint rule
+ * @copyright 2015 Cyan, Inc. All rights reserved
+*/
+
+'use strict';
+
+var t = require('../../src/transplant')(__dirname);
+var noDupeFunc = t.require('./no-dupe-func');
+
+describe('noDupeFunc', function () {
+    it('exists', function () {
+        expect(noDupeFunc).not.toBeUndefined();
+    });
+
+    it('is a function', function () {
+        expect(typeof noDupeFunc).toBe('function');
+    });
+});

--- a/src/eslint-rules/no-redeclare-func.js
+++ b/src/eslint-rules/no-redeclare-func.js
@@ -1,0 +1,29 @@
+/**
+ * @fileoverview Rule to flag overriding a previously defined function
+ * @author Adam Meadows
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function (context) {
+
+    'use strict';
+
+    var functionAssignments = {};
+
+    return {
+
+        'AssignmentExpression': function (node) {
+            if (node.right.type === 'FunctionExpression') {
+                var name = context.getSource(node.left);
+                if (functionAssignments[name]) {
+                    context.report(node, 'Duplicate function "{{name}}".', {name: name});
+                } else {
+                    functionAssignments[name] = true;
+                }
+            }
+        },
+    };
+};

--- a/src/init.js
+++ b/src/init.js
@@ -36,6 +36,10 @@ ns.cleanupCruft = function (projectName) {
     return match[1];
 };
 
+function foo() {
+
+}
+
 /**
  * Actual functionality of the 'init' command
  * @param {Ojbect} argv - the minimist arguments object
@@ -43,7 +47,7 @@ ns.cleanupCruft = function (projectName) {
 */
 ns.command = function (argv) {
     var _config = config.load(CWD);
-
+    foo();
     if (!_config) {
         console.error('beaker.json missing');
         console.info('To create a default beaker.json file run the following command: beaker newConfig');

--- a/src/init.js
+++ b/src/init.js
@@ -36,10 +36,6 @@ ns.cleanupCruft = function (projectName) {
     return match[1];
 };
 
-function foo() {
-
-}
-
 /**
  * Actual functionality of the 'init' command
  * @param {Ojbect} argv - the minimist arguments object
@@ -47,7 +43,6 @@ function foo() {
 */
 ns.command = function (argv) {
     var _config = config.load(CWD);
-    foo();
     if (!_config) {
         console.error('beaker.json missing');
         console.info('To create a default beaker.json file run the following command: beaker newConfig');

--- a/src/init.js
+++ b/src/init.js
@@ -43,6 +43,7 @@ ns.cleanupCruft = function (projectName) {
 */
 ns.command = function (argv) {
     var _config = config.load(CWD);
+
     if (!_config) {
         console.error('beaker.json missing');
         console.info('To create a default beaker.json file run the following command: beaker newConfig');


### PR DESCRIPTION
The `no-redeclare-func` rule works much like the `no-redeclare` rule
except that it works when assigning a function to an object property.

For instance, the following will be marked as an error:

```js
let proto = {};

proto.init = function () {
    // original init
};

proto.init = function () {
    // accidental override of init
};
```

NOTE: this must be merged *after* #18 