### PR TITLE
Major version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beaker",
-  "version": "1.5.0",
+  "version": "2.0.0",
   "description": "Toolkit for building web interfaces",
   "main": "src/index.js",
   "repository": {


### PR DESCRIPTION
I didn't realized that the 0.19.0 version of `eslint` defaulted
`comma-dangle` to `never`, so in order to update to the latest
`beaker` you'll want to update your `.eslintrc` as well, so it needs
to be a concious decision, thus the major version bump.