### PR TITLE
Update webpack configs, especially for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
 language: node_js
 node_js:
     - "0.10"
+before_script:
+    - "export DISPLAY=:99.0"
+    - "sh -e /etc/init.d/xvfb start"
+env:
+    - TRAVIS=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,4 @@ before_script:
     - "sh -e /etc/init.d/xvfb start"
 env:
     - TRAVIS=1
+    - SELENIUM_BROWSER=firefox

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ before_script:
     - "export DISPLAY=:99.0"
     - "sh -e /etc/init.d/xvfb start"
 env:
-    - TRAVIS=1
-    - SELENIUM_BROWSER=firefox
+    global:
+        - TRAVIS=1
+        - SELENIUM_BROWSER=firefox

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ before_script:
     - "sh -e /etc/init.d/xvfb start"
 env:
     global:
-        - TRAVIS=1
+        - KARMA_BROWSER=Firefox
         - SELENIUM_BROWSER=firefox

--- a/README.md
+++ b/README.md
@@ -91,7 +91,15 @@ directory. An example of what to add to your `.vimrc` can be found
 
 ## Development
 
-The following `grunt` tasks and `make` targets have been provided to allow for rapid development
+The following `grunt` tasks and `make` targets have been provided to allow for rapid development. By default no
+source-maps are generated, since it affects build-time quite a bit, especially for large projects. However, if you
+would like to generate source-maps, simply set the `MAPS` environment variable to `on`. You can do so per command
+by simply adding `MAPS=on` before the command.
+
+    MAPS=on grunt
+    MAPS=on make webpack-watch-test
+
+This can be useful if you're not sure where a test is failing, or where an exception is being raised.
 
 ### `grunt`
 The default `grunt` task will launch the `webpack-dev-server` in
@@ -193,16 +201,33 @@ sense to have the same package in both `dependencies` and `devDependencies`, sin
 `npm install`.
 
 
-## Packages Installed
+## Components
+`beaker` works with (or depends on) the following tools/packages.
 
-When you install this npm package it will include all of the following npm packages as dependencies:
+### Webpack
+`beaker` primarily helps you set up [`webpack`](http://webpack.github.io) projects.
 
-### Style Sheets
-* [grunt-contrib-less](https://github.com/gruntjs/grunt-contrib-less)
+### Loaders
+`beaker` automatically configures the following `webpack` loaders:
 
-### JavaScript
-* [nconf](https://github.com/flatiron/nconf)
-* [lodash](https://github.com/lodash/lodash)
+#### Styles
+
+ * [less-loader](https://github.com/webpack/less-loader) so you can use [LESS](http://lesscss.org)
+ * [autoprefixer-loader](https://github.com/passy/autoprefixer-loader) so you never have to use browser prefixes.
+ * [css-loader](https://github.com/webpack/css-loader) how else are you gonna deliver your styles?
+ * [style-loader](https://github.com/webpack/style-loader) so you never have to add another `<link>` tag
+ * [file-loader](https://github.com/webpack/file-loader) so you can bundle images and get reference to their URLs.
+
+#### Data
+ * [json-loader](https://github.com/webpack/json-loade://github.com/webpack/json-loader) so you can keep your `.js`
+   files cleaner and keep data where it belongs.
+ * [yaml-loader](https://github.com/okonet/yaml-loader) in case you're lazy and don't wanna write full JSON.
+
+#### Code
+ * [jade-loader](https://github.com/webpack/jade-loader) so you can use client-side
+   [`jade` templates](http://jade-lang.com)
+ * [babel-loader](https://github.com/babel/babel-loade://github.com/babel/babel-loader) so you can write the code of
+   tomorrow, today with [`babel`](https://github.com/babel/babel)
 
 ### Task Management
 * [grunt](https://github.com/gruntjs/grunt)
@@ -211,11 +236,13 @@ When you install this npm package it will include all of the following npm packa
 
 ### Testing / Linting
 * [grunt-karma](https://github.com/karma-runner/grunt-karma)
-* [grunt-eslint](https://github.com/sindresorhus/grunt-eslint)
+* [grunt-eslint](https://github.com/sindresorhus/grunt-eslint) so you can, you guessed it,
+  use [`eslint`](http://eslint.org)
 * [grunt-filenames](https://github.com/bahmutov/grunt-filenames)
 * [karma](https://github.com/karma-runner/karma)
 * [karma-chrome-launcher](https://github.com/karma-runner/karma-chrome-launcher)
 * [karma-cli](https://github.com/karma-runner/karma-cli)
+* [karma-firefox-launcher](https://github.com/karma-runner/karma-firefox-launcher)
 * [karma-js-coverage](https://github.com/danielflower/karma-js-coverage)
 * [karma-jasmine](https://github.com/karma-runner/karma-jasmine)
 * [karma-spec-reporter](https://github.com/mlex/karma-spec-reporter)
@@ -224,5 +251,5 @@ When you install this npm package it will include all of the following npm packa
 We also include code from the following sources.
 
 * [nodeca](https://github.com/nodeca/nodeca/)
-(some [eslint rules](https://github.com/nodeca/nodeca/tree/master/support/eslint_plugins))
+(some [eslint rules](https://github.com/nodeca/eslint-plugin-nodeca/tree/master/lib))`
 

--- a/config/karma/config.js
+++ b/config/karma/config.js
@@ -10,6 +10,9 @@ var webpack = require('webpack');
 var loaders = require('../webpack/loaders');
 var resolve = require('../webpack/resolve');
 
+var USE_SOURCE_MAPS = process.env.MAPS === 'on';
+var TRAVIS = process.env.TRAVIS === '1';
+
 module.exports = function (config) {
     config.set({
         // base path that will be used to resolve all patterns (eg. files, exclude)
@@ -56,7 +59,7 @@ module.exports = function (config) {
 
         // start these browsers
         // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-        browsers: ['Chrome'],
+        browsers: TRAVIS ? ['Firefox'] : ['Chrome'],
 
 
         // Continuous Integration mode
@@ -84,7 +87,7 @@ module.exports = function (config) {
                 }),
             ],
             resolve: resolve,
-            devtool: 'inline-source-map',
+            devtool: USE_SOURCE_MAPS ? 'inline-cheap-module-source-map' : 'eval',
         },
 
         webpackMiddleware: {

--- a/config/karma/config.js
+++ b/config/karma/config.js
@@ -11,7 +11,7 @@ var loaders = require('../webpack/loaders');
 var resolve = require('../webpack/resolve');
 
 var USE_SOURCE_MAPS = process.env.MAPS === 'on';
-var TRAVIS = process.env.TRAVIS === '1';
+var KARMA_BROWSER = process.env.KARMA_BROWSER || 'Chrome';
 
 module.exports = function (config) {
     config.set({
@@ -59,7 +59,7 @@ module.exports = function (config) {
 
         // start these browsers
         // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-        browsers: TRAVIS ? ['Firefox'] : ['Chrome'],
+        browsers: [KARMA_BROWSER],
 
 
         // Continuous Integration mode

--- a/config/karma/config.js
+++ b/config/karma/config.js
@@ -96,6 +96,7 @@ module.exports = function (config) {
 
         plugins: [
             require('karma-chrome-launcher'),
+            require('karma-firefox-launcher'),
             require('karma-jasmine-jquery'),
             require('karma-jasmine'),
             require('karma-js-coverage'),

--- a/files/beaker.json
+++ b/files/beaker.json
@@ -1,11 +1,16 @@
 {
     "author": "First Last <first.last@example.com>",
-    "company": "",
+    "company": "Acme, Co.",
     "github": {
         "email": "",
         "host": "github.com",
         "token": "",
         "user": ""
+    },
+    "selenium": {
+      "host": "localhost",
+      "port": 4444,
+      "browser": "chrome"
     },
     "npm": {
         "registry": "https://registry.npmjs.com"

--- a/files/project-templates/app/Makefile
+++ b/files/project-templates/app/Makefile
@@ -3,9 +3,14 @@
 # Copyright (c) {{ year }} {{ company }}. All rights reserved.
 #
 
-GITHUB_HOST := github.com
+GITHUB_HOST := {{ githubHost }}
 REPO := {{ githubUser }}/{{ projectName }}
 PROJECT_NAME := {{ projectName }}
+
+# Uncomment these if you want to override the default Selenium configs
+#SELENIUM_HOST ?= {{ seleniumHost }}
+#SELENIUM_PORT ?= {{ seleniumPort }}
+#SELENIUM_BROWSER ?= {{ seleniumBrowser }}
 
 -include node_modules/beaker/make/common.mk
 -include node_modules/beaker/make/gh-pages.mk
@@ -13,18 +18,17 @@ PROJECT_NAME := {{ projectName }}
 
 .PHONY: install clean test coverage report-coverage release ghp-update
 
+# NOTE: install target will not have loaded the include above
+# from beaker, so you don't have the ENV or SHELL variables set
+# The karma-jasmine-jquery package doesn't do postinstall properly when a peer dep,
+# So we do its postinstall step again at the end
 install:
-	# NOTE: install target will not have loaded the include above
-	# from beaker, so you don't have the ENV or SHELL variables set
-	$(eval ENV := source env.sh && )
-	$(eval SHELL := bash)
 	$(HIDE)npm install
-	# The karma-jasmine-jquery package doesn't do postinstall properly when a peer dep,
-	# So we do it's postinstall step again at the end
 	$(HIDE)cd node_modules/karma-jasmine-jquery && node install.js
+	$(HIDE)node node_modules/.bin/webdriver-manager update --standalone
 
 clean:
-	$(HIDE)rm -rf bundle
+	$(HIDE)rm -rf bundle coverage
 
 test: webpack-test
 

--- a/files/project-templates/app/webpack.config.js
+++ b/files/project-templates/app/webpack.config.js
@@ -13,7 +13,7 @@ module.exports = {
         app: './src/index.6.js',
     },
 
-    devtool: 'source-map',
+    devtool: 'cheap-module-source-map',
 
     output: {
         path: 'bundle',

--- a/files/project-templates/webpack/Makefile
+++ b/files/project-templates/webpack/Makefile
@@ -3,8 +3,13 @@
 # Copyright (c) {{ year }} {{ company }}. All rights reserved.
 #
 
-GITHUB_HOST := github.com
+GITHUB_HOST := {{ githubHost }}
 REPO := {{ githubUser }}/{{ projectName }}
+
+# Uncomment these if you want to override the default Selenium configs
+#SELENIUM_HOST ?= {{ seleniumHost }}
+#SELENIUM_PORT ?= {{ seleniumPort }}
+#SELENIUM_BROWSER ?= {{ seleniumBrowser }}
 
 -include node_modules/beaker/make/common.mk
 -include node_modules/beaker/make/gh-pages.mk
@@ -12,17 +17,14 @@ REPO := {{ githubUser }}/{{ projectName }}
 
 .PHONY: install clean test coverage report-coverage release ghp-update
 
+# NOTE: install target will not have loaded the include above
+# from beaker, so you don't have the ENV or SHELL variables set
+# The karma-jasmine-jquery package doesn't do postinstall properly when a peer dep,
+# So we do its postinstall step again at the end
 install:
-	# NOTE: install target will not have loaded the include above
-	# from beaker, so you don't have the ENV or SHELL variables set
-	$(eval ENV := source env.sh && )
-	$(eval SHELL := bash)
 	$(HIDE)npm install
-	# The karma-jasmine-jquery package doesn't do postinstall properly when a peer dep,
-	# So we do it's postinstall step again at the end
 	$(HIDE)cd node_modules/karma-jasmine-jquery && node install.js
 	$(HIDE)node node_modules/.bin/webdriver-manager update --standalone
-
 
 clean:
 	$(HIDE)rm -rf coverage demo/bundle

--- a/files/project-templates/webpack/spec/e2e/main-spec.js
+++ b/files/project-templates/webpack/spec/e2e/main-spec.js
@@ -9,8 +9,8 @@
 
 var webdriverio = require('webdriverio');
 var webdrivercss = require('webdrivercss');
-var NORMAL_VIEWPORT_WIDTH = 1300;
-var NORMAL_VIEWPORT_HEIGHT = 600;
+var NORMAL_VIEWPORT_WIDTH = 1280;
+var NORMAL_VIEWPORT_HEIGHT = 800;
 var SMALL_VIEWPORT_WIDTH = 900;
 
 var testConfig = require('./test-config.json');
@@ -22,7 +22,10 @@ describe('{{ projectName }} e2e tests using ' + testConfig.url, function () {
 
     beforeEach(function () {
         var wdIoOptions = {
-            desiredCapabilities: {browserName: 'chrome'},
+            desiredCapabilities: {browserName: testConfig.selenium.browser},
+            host: testConfig.selenium.host,
+            port: testConfig.selenium.port,
+            logLevel: 'silent',
         };
         client = webdriverio.remote(wdIoOptions);
         client.init();

--- a/files/project-templates/webpack/webpack.config.js
+++ b/files/project-templates/webpack/webpack.config.js
@@ -14,7 +14,7 @@ module.exports = {
         demo: './demo/js/demo.6.js',
     },
 
-    devtool: 'source-map',
+    devtool: 'cheap-module-source-map',
 
     output: {
         path: 'demo/bundle',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beaker",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Toolkit for building web interfaces",
   "main": "src/index.js",
   "repository": {
@@ -31,9 +31,10 @@
     "http-server": "^0.7.4",
     "istanbul": "^0.3.5",
     "jasmine-node": "^2.0.0",
+    "karma": "^0.12.31",
     "matchdep": "^0.3.0",
     "nock": "^0.59.1",
-    "webpack": "1.6.0"
+    "webpack": "^1.8.11"
   },
   "dependencies": {
     "change-case": "^2.2.0",
@@ -48,7 +49,7 @@
   },
   "peerDependencies": {
     "autoprefixer-loader": "^1.1.0",
-    "babel-loader": "^4.0.0",
+    "babel-loader": "^5.0.0",
     "css-loader": "^0.9.1",
     "csso": "^1.3.11",
     "eslint": "^0.19.0",
@@ -68,6 +69,7 @@
     "karma": "^0.12.31",
     "karma-chrome-launcher": "^0.1.7",
     "karma-cli": "^0.0.4",
+    "karma-firefox-launcher": "^0.1.4",
     "karma-js-coverage": "^0.4.0",
     "karma-jasmine": "^0.3.5",
     "karma-jasmine-jquery": "^0.1.1",
@@ -79,13 +81,13 @@
     "matchdep": "^0.3.0",
     "style-loader": "^0.8.3",
     "yaml-loader": "^0.1.0",
-    "webpack": "1.6.0",
-    "webpack-dev-server": "^1.7.0"
+    "webpack": "^1.8.11",
+    "webpack-dev-server": "^1.8.2"
   },
   "scripts": {
     "prepublish": "bin/pre-publish.sh",
     "postpublish": "bin/post-publish.sh",
-    "test": "make lint && make node-test"
+    "test": "make lint && make test"
   },
   "bin": {
     "beaker": "./bin/beaker.js",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
   "scripts": {
     "prepublish": "bin/pre-publish.sh",
     "postpublish": "bin/post-publish.sh",
-    "test": "make lint && make test"
+    "test": "make lint && make node-test"
   },
   "bin": {
     "beaker": "./bin/beaker.js",

--- a/spec/init-spec.js
+++ b/spec/init-spec.js
@@ -55,6 +55,9 @@ describe('init', function () {
             npmRegistry: config.npm.registry,
             beakerVersion: require('../package.json').version,
             cruftlessName: 'NON-APP',
+            seleniumHost: 'localhost',
+            seleniumPort: 4444,
+            seleniumBrowser: 'chrome',
             templateDir: path.join(CWD, 'files/project-templates'),
         };
 

--- a/spec/sample-config.json
+++ b/spec/sample-config.json
@@ -1,11 +1,16 @@
 {
-    "github": {
-        "email": "buildbot@example.com",
-        "host": "github.com",
-        "token": "correcthorsebatterystaple",
-        "user": "cyaninc"
-    },
-    "npm": {
-        "registry": "http://npmjs.org"
-    }
+  "github": {
+    "email": "buildbot@example.com",
+    "host": "github.com",
+    "token": "correcthorsebatterystaple",
+    "user": "cyaninc"
+  },
+  "selenium": {
+    "host": "localhost",
+    "port": 4444,
+    "browser": "chrome"
+  },
+  "npm": {
+    "registry": "http://npmjs.org"
+  }
 }

--- a/src/config.js
+++ b/src/config.js
@@ -35,8 +35,13 @@ ns.load = function (dir) {
         github: {
             host: 'github.com',
         },
+        selenium: {
+            host: 'localhost',
+            port: 4444,
+            browser: 'chrome',
+        },
         npm: {
-            registry: 'http://npmjs.org',
+            registry: 'https://registry.npmjs.com',
         },
     });
 };

--- a/src/grunt/helper.js
+++ b/src/grunt/helper.js
@@ -16,6 +16,8 @@ var configDir = path.join(__dirname, '../../config');
 var webpackLoaders = require(path.join(configDir, 'webpack/loaders'));
 var webpackResolve = require(path.join(configDir, 'webpack/resolve'));
 
+var USE_SOURCE_MAPS = process.env.MAPS === 'on';
+
 var ns = {};
 
 /**
@@ -198,7 +200,7 @@ ns.init = function (grunt) {
                 contentBase: './demo',
                 keepAlive: true,
                 webpack: {
-                    devtool: 'eval-source-map',
+                    devtool: USE_SOURCE_MAPS ? 'inline-cheap-module-eval-source-map' : 'eval',
                     debug: true,
                     plugins: [
                         new webpack.DefinePlugin({

--- a/src/init.js
+++ b/src/init.js
@@ -67,6 +67,9 @@ ns.command = function (argv) {
         githubUser: _config.github.user,
         npmRegistry: _config.npm.registry,
         beakerVersion: utils.pkg.version,
+        seleniumHost: _config.selenium.host,
+        seleniumPort: _config.selenium.port,
+        seleniumBrowser: _config.selenium.browser,
         cruftlessName: cruftlessName,
         templateDir: _config.templateDir || FILES_DIR,
     };


### PR DESCRIPTION
This release provides the following:

 * Updates to the latest `webpack` and un-pins it so we pick up non-breaking changes again.
 * Adds support for an environment variable `MAPS` which must be set to `on` to enable
   source-maps during development and testing
 * Sets the browser for karma-testing to Firefox when running on travis since they don't have Chrome
 * Enabled full tests on travis