### PR TITLE
Added support for loading bootstrap modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ sense to have the same package in both `dependencies` and `devDependencies`, sin
  * [babel-loader](https://github.com/babel/babel-loade://github.com/babel/babel-loader) so you can write the code of
    tomorrow, today with [`babel`](https://github.com/babel/babel)
  * [imports-loader](https://github.com/webpack/imports-loader) so you can include code that was intended to be
-   included directly in a `<script>` tag. 
+   included directly in a `<script>` tag.
 
 ### Task Management
 * [grunt](https://github.com/gruntjs/grunt)
@@ -240,5 +240,5 @@ sense to have the same package in both `dependencies` and `devDependencies`, sin
 We also include code from the following sources.
 
 * [nodeca](https://github.com/nodeca/nodeca/)
-(some [eslint rules](https://github.com/nodeca/eslint-plugin-nodeca/tree/master/lib))`
+(some [eslint rules](https://github.com/nodeca/eslint-plugin-nodeca/tree/master/lib))
 

--- a/config/webpack/loaders.js
+++ b/config/webpack/loaders.js
@@ -27,6 +27,9 @@ var loaders = [
     }, {
         test: /\.(svg|woff|woff2|eot|dtd|png|gif|jpg|jpeg|ttf)(\?.*)?$/,
         loader: 'file',
+    }, {
+        test: /bootstrap\/js\//,
+        loader: 'imports?jQuery=jquery',
     },
 ];
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "beaker",
-    "version": "3.5.2",
+    "version": "3.6.0",
     "description": "Toolkit for building web interfaces",
     "keywords": [
         "tools",


### PR DESCRIPTION
So, it turns out using `imports-loader` to load `bootstrap` doesn't work
if you just do

```js
require('imports?jQuery=jquery!bootstrap');
```

Because `bootstrap` itself uses `require` to load sub-modules and each of
them need to have `jQuery` present as well, so you need to tell `webpack` to
use the `imports` loader on all `bootstrap` modules.