### PR TITLE
Pinning babel b/c a recent change broke our code

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "beaker",
-    "version": "3.5.2",
+    "version": "3.5.3",
     "description": "Toolkit for building web interfaces",
     "keywords": [
         "tools",
@@ -94,7 +94,8 @@
     },
     "peerDependencies": {
         "autoprefixer-loader": "^1.1.0",
-        "babel-loader": "^5.0.0",
+        "babel-core": "5.3.3",
+        "babel-loader": "5.0.0",
         "coveralls": "^2.11.2",
         "css-loader": "^0.9.1",
         "csso": "^1.3.11",


### PR DESCRIPTION
Latest babel didn't allow us to use `foo={foo}` in jsx