### PR TITLE
Added JASMINE env when running unit tests

### DIFF
--- a/make/karma-targets.mk
+++ b/make/karma-targets.mk
@@ -8,14 +8,17 @@
 	karma-test \
 	karma-watch
 
+karma-coverage: export JASMINE=1
 karma-coverage:
 	$(HIDE)echo "Running Karma tests (with coverage)"
 	$(ENV)grunt test-coverage
 
+karma-watch: export JASMINE=1
 karma-watch:
 	$(HIDE)echo "Running Karma tests (with watching)"
 	$(ENV)grunt karma:unit watch:karma
 
+karma-test: export JASMINE=1
 karma-test:
 	$(HIDE)echo "Running Karma tests once"
 	$(ENV)grunt test

--- a/make/node-targets.mk
+++ b/make/node-targets.mk
@@ -30,17 +30,21 @@ $(JASMINE_CONFIG_FILE):
 	$(HIDE)echo "    ]" >> $@
 	$(HIDE)echo "}" >> $@
 
+
 jasmine-coveralls:
 	$(ENV)cat $(NODE_COVERAGE_DIR)/lcov.info | coveralls
 
 export JASMINE_CONFIG_PATH = $(JASMINE_CONFIG_FILE)
 export NODE_SPECS
+jasmine-coverage: export JASMINE=1
 jasmine-coverage:
 	$(HIDE)echo "Running istanbul coverage on jasmine node specs"
+	$(HIDE)echo "Running jasmine node specs JASMINE=[$$JASMINE]"
 	$(ENV)istanbul cover $(NODE_COVERAGE_OPTS) jasmine
 
+jasmine-test: export JASMINE=1
 jasmine-test:
-	$(HIDE)echo "Running jasmine node specs"
+	$(HIDE)echo "Running jasmine node specs JASMINE=[$$JASMINE]"
 	$(ENV)jasmine
 
 # =================================================================================================

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "beaker",
-    "version": "3.5.3",
+    "version": "3.6.0",
     "description": "Toolkit for building web interfaces",
     "keywords": [
         "tools",


### PR DESCRIPTION
The `JASMINE` environment variable can be used to determine when
in unit test mode in case you wanna make sure something doesn't
happen when unit testing, like, perhaps, making an un-mocked API call.