### PR TITLE
Actually enable the webpack global for JASMINE

### DIFF
--- a/config/karma/config.js
+++ b/config/karma/config.js
@@ -89,7 +89,9 @@ module.exports = function (config) {
             },
             plugins: [
                 new webpack.DefinePlugin({
-                    MOCK_APIS: false,
+                    'process.env': {
+                        'JASMINE': process.env.JASMINE,
+                    },
                 }),
             ],
             resolve: resolve,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "beaker",
-    "version": "3.6.0",
+    "version": "3.6.1",
     "description": "Toolkit for building web interfaces",
     "keywords": [
         "tools",


### PR DESCRIPTION
Just setting `process.env.JASMINE` isn't enough, `webpack` needs
to translate it into a global at compile-time.