### PR TITLE
Handling first case where there are no screenshots

### DIFF
--- a/make/e2e-targets.mk
+++ b/make/e2e-targets.mk
@@ -52,7 +52,7 @@ create-config:
 SCREENSHOTS_DIR := spec/e2e/screenshots
 clean-screenshots:
 	$(HIDE)echo "Removing everything but *.baseline.png files from $(SCREENSHOTS_DIR)"
-	$(HIDE)find $(SCREENSHOTS_DIR) -type f ! -name *.baseline.png -exec rm -f {} \;
+	$(HIDE)find $(SCREENSHOTS_DIR) -type f ! -name *.baseline.png -exec rm -f {} \; || echo "No screenshots present"
 
 do-e2e-test:
 ifndef JASMINE_CONFIG_FILE

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "beaker",
-    "version": "3.6.2",
+    "version": "3.6.3",
     "description": "Toolkit for building web interfaces",
     "keywords": [
         "tools",


### PR DESCRIPTION
As it stood, you could never generate your first screenshots with
`make remote-e2e-test` because the `clean-screenshots` would fail if
there were no `.png` files in `spec/e2e/screenshots`. Now, you can
actually generate your initial screenshots.