### PR TITLE
Add support for mocha

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,43 @@ This is a simple make target that does a `grunt karma:unit watch:karma`. This wi
 start and a watcher to be placed on all the files in `src/`. So, when any file is changed, all your karma tests
 will be run. It's still a little slow because of the source-maps being generated.
 
+## Testing Framework
+By default `beaker` uses `Jasmine` for tests. If you prefer to use `mocha` you can simply follow the below steps.
+
+1. Add the following to the top of your `Makefile`:
+
+    ```
+    TESTING_FRAMEWORK := mocha
+    ```
+
+2. Add the following `devDependencies` to your `package.json`:
+    * `karma-chai-jquery`
+    * `karma-jquery`
+    * `karma-mocha`
+    * `karma-sinon-chai`
+    * `mocha`
+
+3. Update your `spec/.eslintrc` file to be:
+
+    ```
+    {
+        "globals": {
+            "describe": false,
+            "xdescribe": false,
+            "beforeEach": false,
+            "afterEach": false,
+            "it": false,
+            "xit": false,
+            "expect": false,
+            "console": false,
+            "sinon": false
+        },
+        "rules": {
+            "max-nested-callbacks": 0,
+            "no-unused-expressions": 0
+        }
+    ```
+
 ## Contributing
 
 If you are going to be adding functionality to `beaker` keep in mind the following regarding dependencies.

--- a/config/karma/config.js
+++ b/config/karma/config.js
@@ -21,6 +21,42 @@ var entryPointFull = path.join(BEAKER_DIR, 'config/karma', entryPoint);
 var preprocessors = {};
 preprocessors[entryPointFull] = ['webpack', 'sourcemap'];
 
+var frameworks = [];
+var plugins = [
+    require('karma-chrome-launcher'),
+    require('karma-firefox-launcher'),
+    require('karma-js-coverage'),
+    require('karma-sourcemap-loader'),
+    require('karma-spec-reporter'),
+    require('karma-webpack'),
+];
+
+if (process.env.TEST_FRAMEWORK === 'mocha') {
+    frameworks.push(
+        'mocha',
+        'chai-jquery',
+        'sinon-chai',
+        'jquery-2.1.0'
+    );
+
+    plugins.push(
+        require('karma-chai-jquery'),
+        require('karma-jquery'),
+        require('karma-mocha'),
+        require('karma-sinon-chai')
+    );
+} else {
+    frameworks.push(
+        'jasmine-jquery',
+        'jasmine'
+    );
+
+    plugins.push(
+        require('karma-jasmine-jquery'),
+        require('karma-jasmine')
+    );
+}
+
 module.exports = function (config) {
     config.set({
         // base path that will be used to resolve all patterns (eg. files, exclude)
@@ -28,7 +64,7 @@ module.exports = function (config) {
 
         // frameworks to use
         // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
-        frameworks: ['jasmine-jquery', 'jasmine'],
+        frameworks: frameworks,
 
         // list of files / patterns to load in the browser
         files: [
@@ -102,16 +138,7 @@ module.exports = function (config) {
             noInfo: false,
         },
 
-        plugins: [
-            require('karma-chrome-launcher'),
-            require('karma-firefox-launcher'),
-            require('karma-jasmine-jquery'),
-            require('karma-jasmine'),
-            require('karma-js-coverage'),
-            require('karma-sourcemap-loader'),
-            require('karma-spec-reporter'),
-            require('karma-webpack'),
-        ],
+        plugins: plugins,
 
     });
 };

--- a/make/karma-targets.mk
+++ b/make/karma-targets.mk
@@ -3,22 +3,27 @@
 # Copyright (c) 2015 Cyan, Inc. All rights reserved.
 #
 
+TESTING_FRAMEWORK ?= jasmine
+
 .PHONY: \
 	karma-coverage \
 	karma-test \
 	karma-watch
 
 karma-coverage: export JASMINE=1
+karma-coverage: export TEST_FRAMEWORK=$(TESTING_FRAMEWORK)
 karma-coverage:
 	$(HIDE)echo "Running Karma tests (with coverage)"
 	$(ENV)grunt test-coverage
 
 karma-watch: export JASMINE=1
+karma-watch: export TEST_FRAMEWORK=$(TESTING_FRAMEWORK)
 karma-watch:
 	$(HIDE)echo "Running Karma tests (with watching)"
 	$(ENV)grunt karma:unit watch:karma
 
 karma-test: export JASMINE=1
+karma-test: export TEST_FRAMEWORK=$(TESTING_FRAMEWORK)
 karma-test:
 	$(HIDE)echo "Running Karma tests once"
 	$(ENV)grunt test

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "beaker",
-    "version": "3.6.3",
+    "version": "3.7.3",
     "description": "Toolkit for building web interfaces",
     "keywords": [
         "tools",


### PR DESCRIPTION
This adds the ability to use `mocha` instead of `jasmine` as your test framework.