### PR TITLE
Removed production NODE_ENV from default config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "beaker",
-    "version": "3.8.2",
+    "version": "3.8.3",
     "description": "Toolkit for building web interfaces",
     "keywords": [
         "tools",

--- a/src/grunt/helper.js
+++ b/src/grunt/helper.js
@@ -157,12 +157,6 @@ ns.init = function (grunt) {
             options: webpackConfig,
             build: {
                 plugins: webpackConfig.plugins.concat(
-                    new webpack.DefinePlugin({
-                        'process.env': {
-                            // This has effect on the react lib size
-                            'NODE_ENV': JSON.stringify('production'),
-                        },
-                    }),
                     new webpack.optimize.DedupePlugin(),
                     new webpack.optimize.UglifyJsPlugin()
                 ),


### PR DESCRIPTION
Previously, we had a default webpack config setting the `NODE_ENV` to
`production` when doing a `make build`. However, we've noticed some
odd errors (like missing carets in drop-downs) when that environment
variable is set to `production` now, so disabling it by default.