### PR TITLE
Fixed bug in CLI error processing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,10 @@ init-test: webpack.init-test node.init-test app.init-test
 	$(HIDE)./bin/post-publish.sh
 	$(HIDE)npm cache clean beaker
 
-test: lint jasmine-test karma-test
+test-cli-errors:
+	$(HIDE)./bin/test-error-handling.sh
+
+test: lint jasmine-test karma-test test-cli-errors
 
 coverage: node-coverage
 

--- a/bin/beaker.js
+++ b/bin/beaker.js
@@ -13,7 +13,7 @@ var exit = require('exit');
 var cli = require('../src/cli');
 var argv = require('minimist')(process.argv.slice(2), {'boolean': 'app'});
 
-process.on('unhandledException', function (err) {
+process.on('uncaughtException', function (err) {
     var exitCode = 1;
     if (err.exitCode !== undefined) {
         exitCode = err.exitCode;

--- a/bin/test-error-handling.sh
+++ b/bin/test-error-handling.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+#
+# Script to verify proper error handling in CLI
+#
+
+EXPECTED_OUTPUT='Invalid command "foo"'
+OUTPUT_FILE=.test-error-reporting-output
+
+./bin/beaker.js foo > ${OUTPUT_FILE} 2>&1
+OUTPUT=$(cat ${OUTPUT_FILE})
+rm -f ${OUTPUT_FILE}
+
+if [ "${OUTPUT}" != "${EXPECTED_OUTPUT}" ]
+then
+    echo "ERROR: actual output did not match expected output"
+    echo "expected:"
+    echo "${EXPECTED_OUTPUT}"
+    echo "actual:"
+    echo "${OUTPUT}"
+    exit 1
+fi

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "beaker",
-    "version": "3.8.3",
+    "version": "3.8.4",
     "description": "Toolkit for building web interfaces",
     "keywords": [
         "tools",


### PR DESCRIPTION
It turns out I had the name of the event wrong. I was using
`unhandledException` instead of `uncaughtException` and we didn't
have any tests to exercise the proper display of errors.

I've added the test, and made the fix. We should get actual error
messages now, instead of the cryptic

```
path/to/project/node_modules/beaker/src/cli/utils.js:21
            exitCode: exitCode,
                      ^
```