### PR TITLE
Fixed coverage test case when using rewire

### DIFF
--- a/config/karma/config.js
+++ b/config/karma/config.js
@@ -7,9 +7,9 @@
 
 var path = require('path');
 var webpack = require('webpack');
-var RewirePlugin = require('rewire-webpack');
 var loaders = require('../webpack/loaders');
 var resolve = require('../webpack/resolve');
+var webpackPlugins = require('../webpack/karma-plugins');
 
 var USE_SOURCE_MAPS = process.env.MAPS === 'on';
 var KARMA_BROWSER = process.env.KARMA_BROWSER || 'Chrome';
@@ -124,14 +124,7 @@ module.exports = function (config) {
                 ],
                 loaders: loaders,
             },
-            plugins: [
-                new webpack.DefinePlugin({
-                    'process.env': {
-                        'JASMINE': process.env.JASMINE,
-                    },
-                }),
-                new RewirePlugin(),
-            ],
+            plugins: webpackPlugins,
             resolve: resolve,
             devtool: USE_SOURCE_MAPS ? 'inline-cheap-module-source-map' : 'eval',
         },

--- a/config/webpack/karma-plugins.js
+++ b/config/webpack/karma-plugins.js
@@ -1,0 +1,18 @@
+/**
+ * @author Adam Meadows [@job13er](https://github.com/job13er)
+ * @copyright 2015 Cyan, Inc. All rights reserved.
+ */
+
+'use strict';
+
+var RewirePlugin = require('rewire-webpack');
+var webpack = require('webpack');
+
+module.exports = [
+    new webpack.DefinePlugin({
+        'process.env': {
+            'JASMINE': process.env.JASMINE,
+        },
+    }),
+    new RewirePlugin(),
+];

--- a/config/webpack/loaders.js
+++ b/config/webpack/loaders.js
@@ -5,7 +5,7 @@
 
 'use strict';
 
-var loaders = [
+module.exports = [
     {
         test: /\.css$/,
         loader: 'style!css!autoprefixer',
@@ -29,5 +29,3 @@ var loaders = [
         loader: 'file',
     },
 ];
-
-module.exports = loaders;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "beaker",
-    "version": "3.9.0",
+    "version": "3.9.1",
     "description": "Toolkit for building web interfaces",
     "keywords": [
         "tools",

--- a/src/grunt/helper.js
+++ b/src/grunt/helper.js
@@ -15,6 +15,7 @@ var webpack = require('webpack');
 var configDir = path.join(__dirname, '../../config');
 var webpackLoaders = require(path.join(configDir, 'webpack/loaders'));
 var webpackResolve = require(path.join(configDir, 'webpack/resolve'));
+var webpackPlugins = require(path.join(configDir, 'webpack/karma-plugins'));
 
 var USE_SOURCE_MAPS = process.env.MAPS === 'on';
 
@@ -147,7 +148,7 @@ ns.init = function (grunt) {
                             },
                         ],
                     },
-
+                    plugins: webpackPlugins,
                     resolve: webpackResolve,
                 },
             },


### PR DESCRIPTION
Forgot to update the `coverage` `karma` configs with the `RewirePlugin`, to keep it from happening again, I've pulled the `plugins` into a common module that both the normal and coverage `karma` configs use. 