### PR TITLE
Allow stubbing of components with additional methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "beaker",
-    "version": "3.9.1",
+    "version": "3.10.1",
     "description": "Toolkit for building web interfaces",
     "keywords": [
         "tools",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "beaker",
-    "version": "3.10.1",
+    "version": "3.10.0",
     "description": "Toolkit for building web interfaces",
     "keywords": [
         "tools",

--- a/spec/karma/test-utils/jasmine/stub-components-spec.6.js
+++ b/spec/karma/test-utils/jasmine/stub-components-spec.6.js
@@ -13,6 +13,7 @@ const React = require('react/addons');
 
 describe('stubComponents', () => {
     let stubComponents, revert, rewiredModule, components, stubDeps;
+
     beforeEach(() => {
         stubComponents = rewire('../../../../src/test-utils/jasmine/stub-components');
         stubDeps = jasmine.createSpy('stubDeps');
@@ -21,39 +22,97 @@ describe('stubComponents', () => {
         });
 
         rewiredModule = {name: 'my-module'};
-        components = ['Grid', 'Row', 'Col'];
-
-        stubComponents(rewiredModule, components);
     });
 
-    afterEach(() => {
-        revert();
-    });
-
-    it('calls stubDeps()', () => {
-        expect(stubDeps).toHaveBeenCalledWith(rewiredModule, jasmine.any(Object));
-    });
-
-    ['Grid', 'Row', 'Col'].forEach(component => {
-        it(`replaces ${component} with a stub`, () => {
-            const stubs = stubDeps.calls.argsFor(0)[1];
-            expect(stubs[component].displayName).toBe(component);
-        });
-    });
-
-    describe('when stub is rendered', () => {
-        let Grid, component;
+    describe('simple components', () => {
         beforeEach(() => {
-            Grid = stubDeps.calls.argsFor(0)[1].Grid;
-            component = React.addons.TestUtils.renderIntoDocument(
-                <Grid />,
-                document.body
-            );
+            components = ['Grid', 'Row', 'Col'];
+
+            stubComponents(rewiredModule, components);
         });
 
-        it('has the appropriate classes', () => {
-            expect($(React.findDOMNode(component))).toHaveClass('Grid');
-            expect($(React.findDOMNode(component))).toHaveClass('stub');
+        afterEach(() => {
+            revert();
+        });
+
+        it('calls stubDeps()', () => {
+            expect(stubDeps).toHaveBeenCalledWith(rewiredModule, jasmine.any(Object));
+        });
+
+        ['Grid', 'Row', 'Col'].forEach(component => {
+            it(`replaces ${component} with a stub`, () => {
+                const stubs = stubDeps.calls.argsFor(0)[1];
+                expect(stubs[component].displayName).toBe(component);
+            });
+        });
+
+        describe('when stub is rendered', () => {
+            let Grid, component;
+            beforeEach(() => {
+                Grid = stubDeps.calls.argsFor(0)[1].Grid;
+                component = React.addons.TestUtils.renderIntoDocument(
+                    <Grid />,
+                    document.body
+                );
+            });
+
+            it('has the appropriate classes', () => {
+                expect($(React.findDOMNode(component))).toHaveClass('Grid');
+                expect($(React.findDOMNode(component))).toHaveClass('stub');
+            });
+        });
+    });
+
+    describe('complex components', () => {
+        let awesomeMethod;
+
+        beforeEach(() => {
+            awesomeMethod = jasmine.createSpy('Row.awesomeMethod');
+            components = {
+                'Grid': {
+                    awesomeMethod,
+                },
+                'Row': {},
+                'Col': {},
+            };
+
+            stubComponents(rewiredModule, components);
+        });
+
+        afterEach(() => {
+            revert();
+        });
+
+        it('calls stubDeps()', () => {
+            expect(stubDeps).toHaveBeenCalledWith(rewiredModule, jasmine.any(Object));
+        });
+
+        ['Grid', 'Row', 'Col'].forEach(component => {
+            it(`replaces ${component} with a stub`, () => {
+                const stubs = stubDeps.calls.argsFor(0)[1];
+                expect(stubs[component].displayName).toBe(component);
+            });
+        });
+
+        describe('when stub is rendered', () => {
+            let Grid, component;
+            beforeEach(() => {
+                Grid = stubDeps.calls.argsFor(0)[1].Grid;
+                component = React.addons.TestUtils.renderIntoDocument(
+                    <Grid />,
+                    document.body
+                );
+            });
+
+            it('has the appropriate classes', () => {
+                expect($(React.findDOMNode(component))).toHaveClass('Grid');
+                expect($(React.findDOMNode(component))).toHaveClass('stub');
+            });
+
+            it('adds custom methods to stubbed components', () => {
+                component.awesomeMethod();
+                expect(awesomeMethod).toHaveBeenCalled();
+            });
         });
     });
 });

--- a/src/test-utils/jasmine/stub-components.6.js
+++ b/src/test-utils/jasmine/stub-components.6.js
@@ -6,16 +6,18 @@
 
 'use strict';
 
+const _ = require('lodash');
 const React = require('react');
 const stubDeps = require('./stub-deps');
 
 /**
  * Create a stub component
  * @param {String} name - the name of the component
+ * @param {Object} props - props to set on React class
  * @returns {ReactComponent} the stubbed component
  */
-function createStubComponent(name) {
-    return React.createClass({
+function createStubComponent(name, props) {
+    return React.createClass(_.assign({
         displayName: name,
         render: function () {
             const className = `stub ${name}`;
@@ -24,19 +26,26 @@ function createStubComponent(name) {
                 </div>
             );
         },
-    });
+    }, props));
 }
 
 /**
  * Stub out components within the rewired module with simple react components that don't do anything
  * @param {Module} rewiredModule - the module loaded with rewire()
- * @param {String[]} components - the components you want to stub out within rewiredModule
+ * @param {Object|String[]} components - the components you want to stub out within rewiredModule
  */
 function stubComponents(rewiredModule, components) {
     const stubs = {};
-    components.forEach(name => {
-        stubs[name] = createStubComponent(name);
-    });
+
+    if (_.isArray(components)) {
+        components.forEach(name => {
+            stubs[name] = createStubComponent(name, {});
+        });
+    } else {
+        _.forIn(components, (props, name) => {
+            stubs[name] = createStubComponent(name, props);
+        });
+    }
 
     stubDeps(rewiredModule, stubs);
 }


### PR DESCRIPTION
Now you can stub React components with custom methods like so:
```javascript
const React = require('react/addons');
const TestUtils = React.addons.TestUtils;
const rewire = require('rewire');
const stubComponents = require('beaker/src/test-utils/jasmine/stub-components');

const MyComponent = rewire('../../src/index');

describe('MyComponent', () => {
    let component;

    stubComponents(MyComponent, {
        'SubComponent1': {
            someCustomMethod: jasmine.createSpy('SubComponent1.someCustomMethod'),
        },
        'SubComponent2': {},
    });

    beforeEach(() => {
        component = TestUtils.renderIntoDocument(
            <MyComponent />
        );
    });
    …
});
```