### PR TITLE
Enabled check for dupe keys in object literals

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -61,6 +61,7 @@
         "new-cap": 2,
         "no-bitwise": 2,
         "no-caller": 2,
+        "no-dupe-keys": 2,
         "no-empty": 2,
         "no-extend-native": 2,
         "no-floating-decimal": 2,

--- a/files/project-templates/common/.eslintrc
+++ b/files/project-templates/common/.eslintrc
@@ -61,6 +61,7 @@
         "new-cap": 2,
         "no-bitwise": 2,
         "no-caller": 2,
+        "no-dupe-keys": 2,
         "no-empty": 2,
         "no-extend-native": 2,
         "no-floating-decimal": 2,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "beaker",
-    "version": "4.0.0",
+    "version": "4.0.1",
     "description": "Toolkit for building web interfaces",
     "keywords": [
         "tools",


### PR DESCRIPTION
Somewhere along the way, we lost our check for duplicate keys
in object literals. This brings it back.