### PR TITLE
Add Jasmine Matcher for React propType Validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "beaker",
-    "version": "4.0.2",
+    "version": "4.1.0",
     "description": "Toolkit for building web interfaces",
     "keywords": [
         "tools",

--- a/spec/karma/test-utils/jasmine/custom-matchers-spec.6.js
+++ b/spec/karma/test-utils/jasmine/custom-matchers-spec.6.js
@@ -137,4 +137,107 @@ describe('customMatchers', () => {
             });
         });
     });
+
+    describe('.toHaveCorrectPropTypes()', () => {
+        let component, expected, fn, result;
+
+        beforeEach(() => {
+            fn = function () {
+                return 1;
+            };
+
+            component = {
+                propTypes: {
+                    a: 1,
+                    b: 'test',
+                    c: fn,
+                },
+            };
+
+            expected = {
+                a: 1,
+                b: 'test',
+                c: fn,
+            };
+
+            matcher = customMatchers.toHaveCorrectPropTypes();
+        });
+
+        describe('when no errors', () => {
+            beforeEach(() => {
+                result = matcher.compare(component, expected);
+            });
+
+            it('returns a passing result', () => {
+                expect(result.pass).toBeTruthy();
+            });
+        });
+
+        describe('when unknown property in expected', () => {
+            beforeEach(() => {
+                expected.d = 'unknown';
+                result = matcher.compare(component, expected);
+            });
+
+            it('returns a failing result', () => {
+                expect(result.pass).toBeFalsy();
+            });
+
+            it('returns appropriate error message', () => {
+                const error = 'Unknown key "d" in propTypes';
+                expect(result.message).toBe(error);
+            });
+        });
+
+        describe('when property missing from expected', () => {
+            beforeEach(() => {
+                delete expected.c;
+                result = matcher.compare(component, expected);
+            });
+
+            it('returns a failing result', () => {
+                expect(result.pass).toBeFalsy();
+            });
+
+            it('returns appropriate error message', () => {
+                const error = 'Expected key "c" in propTypes';
+                expect(result.message).toBe(error);
+            });
+        });
+
+        describe('when expected validation does not match actual validation', () => {
+            beforeEach(() => {
+                expected.c = function () {
+                    return 4;
+                };
+                result = matcher.compare(component, expected);
+            });
+
+            it('returns a failing result', () => {
+                expect(result.pass).toBeFalsy();
+            });
+
+            it('returns appropriate error message', () => {
+                const error = 'Validation for key "c" does not match expected validation';
+                expect(result.message).toBe(error);
+            });
+        });
+
+        describe('when multiple errors', () => {
+            beforeEach(() => {
+                expected.d = 'unknown';
+                delete expected.c;
+                result = matcher.compare(component, expected);
+            });
+
+            it('returns a failing result', () => {
+                expect(result.pass).toBeFalsy();
+            });
+
+            it('returns appropriate error message', () => {
+                const error = 'Unknown key "d" in propTypes\nExpected key "c" in propTypes';
+                expect(result.message).toBe(error);
+            });
+        });
+    });
 });

--- a/src/test-utils/jasmine/custom-matchers.6.js
+++ b/src/test-utils/jasmine/custom-matchers.6.js
@@ -97,4 +97,55 @@ module.exports = {
             },
         };
     },
+
+    /**
+     * Ensure the react component validates propTypes appropriately
+     * @returns {Matcher} the actual matcher
+     */
+    toHaveCorrectPropTypes: function () {
+        return {
+            /**
+             * Actually compare the actual value against the expected value
+             * @param {ReactComponent} component - component to validate propTypes of
+             * @param {Object} expected - expected propType validations
+             * @returns {MatcherResult} the result of the comparison
+             */
+            compare: function (component, expected) {
+                const result = {
+                    message: '',
+                    pass: false,
+                };
+                const actual = component.propTypes;
+                const errors = [];
+
+                // Make sure each propType has correct validation and make sure test doesn't have extra keys
+                Object.keys(expected).forEach(key => {
+                    if (key in actual) {
+                        if (actual[key] !== expected[key]) {
+                            errors.push(`Validation for key "${ key }" does not match expected validation`);
+                        }
+                    } else {
+                        errors.push(`Unknown key "${ key }" in propTypes`);
+                    }
+                });
+
+                // Make sure test isn't missing any keys from propTypes
+                Object.keys(actual).forEach(key => {
+                    if (key in expected) {
+                        return;
+                    }
+
+                    errors.push(`Expected key "${ key }" in propTypes`);
+                });
+
+                result.pass = (errors.length === 0);
+
+                if (!result.pass) {
+                    result.message = errors.join('\n');
+                }
+
+                return result;
+            },
+        };
+    },
 };


### PR DESCRIPTION
This matcher makes it easy to write tests that validate React components have the expected propType validations. Below is an example:

React Component
```javascript
export default React.createClass({
    propTypes: {
        foo: React.PropTypes.string.isRequired,
        bar: React.PropTypes.bool,
    },
    …
});
```

Test
```javascript
expect(MyComponent).toHaveCorrectPropTypes({
    foo: React.PropTypes.string.isRequired,
    bar: React.PropTypes.bool,
});
```