### PR TITLE
Configure isparta to use babel-plugin-rewire

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "beaker",
-    "version": "5.3.0",
+    "version": "5.3.1",
     "description": "Toolkit for building web interfaces",
     "keywords": [
         "tools",

--- a/src/grunt/helper.js
+++ b/src/grunt/helper.js
@@ -142,7 +142,7 @@ ns.init = function (grunt) {
                             {
                                 test: /\.js$/,
                                 exclude: /(spec|node_modules|karma)/,
-                                loader: 'isparta',
+                                loader: 'isparta?{ babel: {plugins: ["rewire"] } }',
                             },
                         ],
                     },


### PR DESCRIPTION
Fixed the problem when using `babel-plugin-rewire` and running coverage with `isparta`