### PR TITLE
Fixing react/jsx-boolean-value check

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -83,7 +83,7 @@
         "object-curly-spacing": [2, "never"],
         "quotes": [2, "single"],
         "react/display-name": 1,
-        "react/jsx-boolean-value": 1,
+        "react/jsx-boolean-value": [1, "always"],
         "react/jsx-quotes": 1,
         "react/jsx-no-undef": 1,
         "react/jsx-sort-props": 1,

--- a/files/project-templates/common/.eslintrc
+++ b/files/project-templates/common/.eslintrc
@@ -83,7 +83,7 @@
         "object-curly-spacing": [2, "never"],
         "quotes": [2, "single"],
         "react/display-name": 1,
-        "react/jsx-boolean-value": 1,
+        "react/jsx-boolean-value": [1, "always"],
         "react/jsx-quotes": 1,
         "react/jsx-no-undef": 1,
         "react/jsx-sort-props": 1,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "beaker",
-    "version": "5.3.2",
+    "version": "5.3.3",
     "description": "Toolkit for building web interfaces",
     "keywords": [
         "tools",


### PR DESCRIPTION
Apparently the default setting for `react/jsx-boolean-value` recently
changed, because all our code started breaking. Explicitly setting it
to `always` now, which is what I believe the default used to be.